### PR TITLE
Bugfix: non-square avatars aren't available for upload now.

### DIFF
--- a/TipCatDotNet.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/TipCatDotNet.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -158,7 +158,7 @@ namespace TipCatDotNet.Api.Infrastructure
             services.AddTransient<IMemberContextService, MemberContextService>();
             services.AddTransient<IPermissionChecker, PermissionChecker>();
 
-            services.AddTransient<IAwsImageManagementService, AwsImageManagementService>();
+            services.AddTransient<IAwsAvatarManagementService, AwsAvatarManagementService>();
             services.AddTransient<IAvatarManagementService<AccountAvatarRequest>, AccountAvatarManagementService>();
             services.AddTransient<IAvatarManagementService<FacilityAvatarRequest>, FacilityAvatarManagementService>();
             services.AddTransient<IAvatarManagementService<MemberAvatarRequest>, MemberAvatarManagementService>();

--- a/TipCatDotNet.Api/Models/Images/Validators/FormFileValidator.cs
+++ b/TipCatDotNet.Api/Models/Images/Validators/FormFileValidator.cs
@@ -13,7 +13,7 @@ public class FormFileValidator : AbstractValidator<FormFile?>
         if (file is null)
             return new ValidationResult(new List<ValidationFailure>(1)
             {
-                new(nameof(file), "Can't read the file. Probably, the Content-Description header isn't set to 'multipart/form-data'.")
+                new(nameof(file), "Can't read the file. Probably, a file size exceeds 5MB, or a Content-Description header isn't set to 'multipart/form-data'.")
             });
 
         RuleFor(x => x)

--- a/TipCatDotNet.Api/Services/Images/AccountAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/AccountAvatarManagementService.cs
@@ -15,7 +15,7 @@ namespace TipCatDotNet.Api.Services.Images;
 public class AccountAvatarManagementService : IAvatarManagementService<AccountAvatarRequest>
 {
     public AccountAvatarManagementService(IOptionsMonitor<AvatarManagementServiceOptions> options, AetherDbContext context,
-        IAwsImageManagementService awsImageManagementService)
+        IAwsAvatarManagementService awsImageManagementService)
     {
         _awsImageManagementService = awsImageManagementService;
         _context = context;
@@ -85,7 +85,7 @@ public class AccountAvatarManagementService : IAvatarManagementService<AccountAv
     }
 
 
-    private readonly IAwsImageManagementService _awsImageManagementService;
+    private readonly IAwsAvatarManagementService _awsImageManagementService;
     private readonly AetherDbContext _context;
     private readonly AvatarManagementServiceOptions _options;
 }

--- a/TipCatDotNet.Api/Services/Images/AwsAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/AwsAvatarManagementService.cs
@@ -8,9 +8,9 @@ using Microsoft.AspNetCore.Http;
 
 namespace TipCatDotNet.Api.Services.Images;
 
-public class AwsImageManagementService : IAwsImageManagementService
+public class AwsAvatarManagementService : IAwsAvatarManagementService
 {
-    public AwsImageManagementService(IAmazonS3ClientService client)
+    public AwsAvatarManagementService(IAmazonS3ClientService client)
     {
         _client = client;
     }
@@ -38,7 +38,7 @@ public class AwsImageManagementService : IAwsImageManagementService
                 return Result.Failure($"The image is too small. Minimal dimensions are {MinimalWidth}x{MinimalWidth}.");
 
             // Assuming a little calculation error may occur when an original image crops, so here's a tolerance check.
-            var aspectRation = info.ImageWidth / info.ImageHeight;
+            var aspectRation = info.ImageWidth / (float) info.ImageHeight;
             if (aspectRation <= 0.98 || 1.02 <= aspectRation)
                 return Result.Failure("The image must have an aspect ratio close to 1:1.");
 

--- a/TipCatDotNet.Api/Services/Images/FacilityAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/FacilityAvatarManagementService.cs
@@ -15,7 +15,7 @@ namespace TipCatDotNet.Api.Services.Images;
 public class FacilityAvatarManagementService : IAvatarManagementService<FacilityAvatarRequest>
 {
     public FacilityAvatarManagementService(IOptionsMonitor<AvatarManagementServiceOptions> options, AetherDbContext context,
-        IAwsImageManagementService awsImageManagementService)
+        IAwsAvatarManagementService awsImageManagementService)
     {
         _awsImageManagementService = awsImageManagementService;
         _context = context;
@@ -85,7 +85,7 @@ public class FacilityAvatarManagementService : IAvatarManagementService<Facility
     }
 
 
-    private readonly IAwsImageManagementService _awsImageManagementService;
+    private readonly IAwsAvatarManagementService _awsImageManagementService;
     private readonly AetherDbContext _context;
     private readonly AvatarManagementServiceOptions _options;
 }

--- a/TipCatDotNet.Api/Services/Images/IAwsAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/IAwsAvatarManagementService.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace TipCatDotNet.Api.Services.Images;
 
-public interface IAwsImageManagementService
+public interface IAwsAvatarManagementService
 {
     Task<Result> Delete(string bucketName, string key, CancellationToken cancellationToken);
     Task<Result<string>> Upload(string bucketName, FormFile file, string key, CancellationToken cancellationToken);

--- a/TipCatDotNet.Api/Services/Images/MemberAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/MemberAvatarManagementService.cs
@@ -15,7 +15,7 @@ namespace TipCatDotNet.Api.Services.Images;
 public class MemberAvatarManagementService : IAvatarManagementService<MemberAvatarRequest>
 {
     public MemberAvatarManagementService(IOptionsMonitor<AvatarManagementServiceOptions> options, AetherDbContext context,
-        IAwsImageManagementService awsImageManagementService)
+        IAwsAvatarManagementService awsImageManagementService)
     {
         _awsImageManagementService = awsImageManagementService;
         _context = context;
@@ -85,7 +85,7 @@ public class MemberAvatarManagementService : IAvatarManagementService<MemberAvat
     }
 
 
-    private readonly IAwsImageManagementService _awsImageManagementService;
+    private readonly IAwsAvatarManagementService _awsImageManagementService;
     private readonly AetherDbContext _context;
     private readonly AvatarManagementServiceOptions _options;
 }

--- a/TipCatDotNet.ApiTests/AccountAvatarManagementServiceTests.cs
+++ b/TipCatDotNet.ApiTests/AccountAvatarManagementServiceTests.cs
@@ -35,7 +35,7 @@ public class AccountAvatarManagementServiceTests
         _aetherDbContext = aetherDbContextMock.Object;
 
 
-        var awsImageManagementServiceMock = new Mock<IAwsImageManagementService>();
+        var awsImageManagementServiceMock = new Mock<IAwsAvatarManagementService>();
         awsImageManagementServiceMock.Setup(s => s.Upload(It.IsAny<string>(), It.IsAny<FormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Func<string, FormFile, string, CancellationToken, Result<string>>((_, _, key, _) => key));
 
@@ -154,7 +154,7 @@ public class AccountAvatarManagementServiceTests
 
 
     private readonly AetherDbContext _aetherDbContext;
-    private readonly IAwsImageManagementService _awsImageManagementServiceMock;
+    private readonly IAwsAvatarManagementService _awsImageManagementServiceMock;
     private readonly MemberContext _memberContext;
     private readonly IOptionsMonitor<AvatarManagementServiceOptions> _options;
 }

--- a/TipCatDotNet.ApiTests/FacilityAvatarManagementServiceTests.cs
+++ b/TipCatDotNet.ApiTests/FacilityAvatarManagementServiceTests.cs
@@ -35,7 +35,7 @@ public class FacilityAvatarManagementServiceTests
         _aetherDbContext = aetherDbContextMock.Object;
 
 
-        var awsImageManagementServiceMock = new Mock<IAwsImageManagementService>();
+        var awsImageManagementServiceMock = new Mock<IAwsAvatarManagementService>();
         awsImageManagementServiceMock.Setup(s => s.Upload(It.IsAny<string>(), It.IsAny<FormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Func<string, FormFile, string, CancellationToken, Result<string>>((_, _, key, _) => key));
 
@@ -208,7 +208,7 @@ public class FacilityAvatarManagementServiceTests
 
 
     private readonly AetherDbContext _aetherDbContext;
-    private readonly IAwsImageManagementService _awsImageManagementServiceMock;
+    private readonly IAwsAvatarManagementService _awsImageManagementServiceMock;
     private readonly MemberContext _memberContext;
     private readonly IOptionsMonitor<AvatarManagementServiceOptions> _options;
 }

--- a/TipCatDotNet.ApiTests/MemberAvatarManagementServiceTests.cs
+++ b/TipCatDotNet.ApiTests/MemberAvatarManagementServiceTests.cs
@@ -35,7 +35,7 @@ public class MemberAvatarManagementServiceTests
         _aetherDbContext = aetherDbContextMock.Object;
 
 
-        var awsImageManagementServiceMock = new Mock<IAwsImageManagementService>();
+        var awsImageManagementServiceMock = new Mock<IAwsAvatarManagementService>();
         awsImageManagementServiceMock.Setup(s => s.Upload(It.IsAny<string>(), It.IsAny<FormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Func<string, FormFile, string, CancellationToken, Result<string>>((_, _, key, _) => key));
 
@@ -208,7 +208,7 @@ public class MemberAvatarManagementServiceTests
 
 
     private readonly AetherDbContext _aetherDbContext;
-    private readonly IAwsImageManagementService _awsImageManagementServiceMock;
+    private readonly IAwsAvatarManagementService _awsImageManagementServiceMock;
     private readonly MemberContext _memberContext;
     private readonly IOptionsMonitor<AvatarManagementServiceOptions> _options;
 }


### PR DESCRIPTION
Bugfix: non-square avatars aren't available for upload now.
AwsImageManagementService renamed to AwsAvatarManagementService.

Fixes #80 