### PR TITLE
Feature/96 member and account details on payment page

### DIFF
--- a/TipCatDotNet.Api/Controllers/PaymentController.cs
+++ b/TipCatDotNet.Api/Controllers/PaymentController.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using TipCatDotNet.Api.Models.Payments;
@@ -19,27 +18,15 @@ namespace TipCatDotNet.Api.Controllers
 
 
         /// <summary>
-        /// Prepare payment and get details by member code.
+        /// Gets payment details by member code.
         /// </summary>
         /// <param name="memberCode">Member Code</param>
         /// <returns></returns>
-        [HttpGet("{memberCode}/prepare")]
+        [HttpGet("{memberCode}")]
         [ProducesResponseType(typeof(PaymentDetailsResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Prepare([FromRoute] string memberCode)
-            => OkOrBadRequest(await _paymentService.GetPreparationDetails(memberCode));
-
-
-        /// <summary>
-        /// Get payment details by id.
-        /// </summary>
-        /// <param name="paymentId">Payment id</param>
-        /// <returns></returns>
-        [HttpGet("{paymentId}")]
-        [ProducesResponseType(typeof(PaymentDetailsResponse), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> Get([FromRoute] string paymentId)
-            => OkOrBadRequest(await _paymentService.Get(paymentId));
+            => OkOrBadRequest(await _paymentService.Get(memberCode));
 
 
         /// <summary>

--- a/TipCatDotNet.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/TipCatDotNet.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -170,6 +170,7 @@ namespace TipCatDotNet.Api.Infrastructure
             services.AddTransient<IAccountService, Services.HospitalityFacilities.AccountService>();
             services.AddTransient<ITransactionService, TransactionService>();
             services.AddTransient<IPaymentService, PaymentService>();
+            services.AddTransient<IProFormaInvoiceService, ProFormaInvoiceService>();
 
             return services;
         }

--- a/TipCatDotNet.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/TipCatDotNet.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -77,7 +77,8 @@ namespace TipCatDotNet.Api.Infrastructure
             });
 
             var client = new StripeClient(stripeCredentials["privateKey"]);
-            return services.AddSingleton(_ => new PaymentIntentService(client));
+            return services.AddSingleton(_ => new PaymentIntentService(client))
+                .AddTransient(_ => new Stripe.AccountService(client));
         }
 
 

--- a/TipCatDotNet.Api/Models/HospitalityFacilities/FacilityRequest.cs
+++ b/TipCatDotNet.Api/Models/HospitalityFacilities/FacilityRequest.cs
@@ -31,7 +31,7 @@ namespace TipCatDotNet.Api.Models.HospitalityFacilities
         public int? AccountId { get; }
 
 
-        public static FacilityRequest CreateWithAccountId(int accountId)
-            => new(null, string.Empty, string.Empty, accountId);
+        public static FacilityRequest CreateWithAccountIdAndName(int accountId, string name)
+            => new(null, name, string.Empty, accountId);
     }
 }

--- a/TipCatDotNet.Api/Models/HospitalityFacilities/Validators/FacilityRequestValidator.cs
+++ b/TipCatDotNet.Api/Models/HospitalityFacilities/Validators/FacilityRequestValidator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,6 +36,10 @@ namespace TipCatDotNet.Api.Models.HospitalityFacilities.Validators
 
         public ValidationResult ValidateAddDefault(in FacilityRequest request)
         {
+            if (string.IsNullOrWhiteSpace(request.Name))
+                return new ValidationResult(new List<ValidationFailure>(1)
+                    { new(nameof(request.Name), "A default facility has no name. Probably account's name is empty or null.") });
+
             RuleFor(x => x.AccountId)
                 .NotNull()
                 .GreaterThan(0)

--- a/TipCatDotNet.Api/Models/Payments/PaymentDetailsResponse.cs
+++ b/TipCatDotNet.Api/Models/Payments/PaymentDetailsResponse.cs
@@ -5,43 +5,12 @@ namespace TipCatDotNet.Api.Models.Payments
 {
     public readonly struct PaymentDetailsResponse
     {
-        public PaymentDetailsResponse(MemberInfo member)
+        public PaymentDetailsResponse(in MemberInfo member, in ProFormaInvoice proFormaInvoice, PaymentIntent? intent)
         {
             Member = member;
-            ClientSecret = null;
-            PaymentIntentId = null;
-        }
-
-
-        public PaymentDetailsResponse(MemberInfo member, PaymentIntent? intent)
-        {
-            Member = member;
-            ClientSecret = (intent != null) ? intent.ClientSecret : null;
-            PaymentIntentId = (intent != null) ? intent.Id : null;
-        }
-
-
-        public override bool Equals(object? obj)
-            => obj is PaymentDetailsResponse other && Equals(in other);
-
-
-        public bool Equals(in PaymentDetailsResponse other)
-            => Member.Equals(other.Member);
-
-
-        public override int GetHashCode()
-            => Member.GetHashCode();
-
-
-        public static bool operator ==(PaymentDetailsResponse left, PaymentDetailsResponse right)
-        {
-            return left.Equals(right);
-        }
-
-
-        public static bool operator !=(PaymentDetailsResponse left, PaymentDetailsResponse right)
-        {
-            return !(left == right);
+            ClientSecret = intent?.ClientSecret;
+            PaymentIntentId = intent?.Id;
+            ProFormaInvoice = proFormaInvoice;
         }
 
 
@@ -49,17 +18,20 @@ namespace TipCatDotNet.Api.Models.Payments
         public MemberInfo Member { get; }
         public string? ClientSecret { get; }
         public string? PaymentIntentId { get; }
+        public ProFormaInvoice ProFormaInvoice { get; }
 
-
-
+        
         public readonly struct MemberInfo
         {
-            public MemberInfo(int id, string firstName, string lastName, string? avatarUrl)
+            public MemberInfo(int id, string firstName, string lastName, string? position, string? avatarUrl, string accountName, string? facilityName)
             {
                 Id = id;
+                AccountName = accountName;
+                AvatarUrl = avatarUrl;
+                FacilityName = facilityName;
                 FirstName = firstName;
                 LastName = lastName;
-                AvatarUrl = avatarUrl;
+                Position = position;
             }
 
 
@@ -75,25 +47,25 @@ namespace TipCatDotNet.Api.Models.Payments
                 => (Id, FirstName, LastName, AvatarUrl).GetHashCode();
 
 
-            public static bool operator ==(MemberInfo left, MemberInfo right)
-            {
-                return left.Equals(right);
-            }
+            public static bool operator ==(in MemberInfo left, in MemberInfo right) 
+                => left.Equals(right);
 
 
-            public static bool operator !=(MemberInfo left, MemberInfo right)
-            {
-                return !(left == right);
-            }
+            public static bool operator !=(in MemberInfo left, in MemberInfo right) 
+                => !(left == right);
 
 
             [Required]
             public int Id { get; }
             [Required]
+            public string AccountName { get; }
+            public string? AvatarUrl { get; }
+            public string? FacilityName { get; }
+            [Required]
             public string FirstName { get; }
             [Required]
             public string LastName { get; }
-            public string? AvatarUrl { get; }
+            public string? Position { get; }
         }
     }
 }

--- a/TipCatDotNet.Api/Models/Payments/ProFormaInvoice.cs
+++ b/TipCatDotNet.Api/Models/Payments/ProFormaInvoice.cs
@@ -1,0 +1,16 @@
+using HappyTravel.Money.Models;
+
+namespace TipCatDotNet.Api.Models.Payments;
+
+public readonly struct ProFormaInvoice
+{
+    public ProFormaInvoice(MoneyAmount? amount, MoneyAmount serviceFee)
+    {
+        Amount = amount;
+        ServiceFee = serviceFee;
+    }
+
+
+    public MoneyAmount? Amount { get; }
+    public MoneyAmount ServiceFee { get; }
+}

--- a/TipCatDotNet.Api/Services/HospitalityFacilities/AccountService.cs
+++ b/TipCatDotNet.Api/Services/HospitalityFacilities/AccountService.cs
@@ -45,7 +45,7 @@ namespace TipCatDotNet.Api.Services.HospitalityFacilities
             }
 
 
-            async Task<Result<int>> AddAccount()
+            async Task<Result<Account>> AddAccount()
             {
                 var now = DateTime.UtcNow;
 
@@ -64,16 +64,16 @@ namespace TipCatDotNet.Api.Services.HospitalityFacilities
                 _context.Accounts.Add(newAccount);
                 await _context.SaveChangesAsync(cancellationToken);
 
-                return newAccount.Id;
+                return newAccount;
             }
 
-            async Task<Result<(int, int)>> AddDefaultFacility(int accountId)
+            async Task<Result<(int, int)>> AddDefaultFacility(Account account)
             {
-                var (_, isFailure, facilityId) = await _facilityService.AddDefault(accountId, cancellationToken);
+                var (_, isFailure, facilityId) = await _facilityService.AddDefault(account.Id, account.OperatingName, cancellationToken);
 
                 return isFailure 
                     ? Result.Failure<(int, int)>("Default facility hadn't been created.") 
-                    : (accountId, facilityId);
+                    : (account.Id, facilityId);
             }
 
 

--- a/TipCatDotNet.Api/Services/HospitalityFacilities/FacilityService.cs
+++ b/TipCatDotNet.Api/Services/HospitalityFacilities/FacilityService.cs
@@ -59,7 +59,7 @@ namespace TipCatDotNet.Api.Services.HospitalityFacilities
         }
 
 
-        public Task<Result<int>> AddDefault(int accountId, CancellationToken cancellationToken = default)
+        public Task<Result<int>> AddDefault(int accountId, string name, CancellationToken cancellationToken = default)
         {
             return Validate()
                 .Bind(AddDefaultInternal);
@@ -68,7 +68,7 @@ namespace TipCatDotNet.Api.Services.HospitalityFacilities
             Result Validate()
             {
                 var validator = new FacilityRequestValidator(_context);
-                return validator.ValidateAddDefault(FacilityRequest.CreateWithAccountId(accountId)).ToResult();
+                return validator.ValidateAddDefault(FacilityRequest.CreateWithAccountIdAndName(accountId, name)).ToResult();
             }
 
 
@@ -78,7 +78,7 @@ namespace TipCatDotNet.Api.Services.HospitalityFacilities
 
                 var defaultFacility = new Facility
                 {
-                    Name = "Default facility",
+                    Name = name,
                     Address = string.Empty,
                     AccountId = accountId,
                     Created = now,

--- a/TipCatDotNet.Api/Services/HospitalityFacilities/IFacilityService.cs
+++ b/TipCatDotNet.Api/Services/HospitalityFacilities/IFacilityService.cs
@@ -9,7 +9,7 @@ namespace TipCatDotNet.Api.Services.HospitalityFacilities
     public interface IFacilityService
     {
         Task<Result<FacilityResponse>> Add(MemberContext memberContext, FacilityRequest request, CancellationToken cancellationToken = default);
-        Task<Result<int>> AddDefault(int accountId, CancellationToken cancellationToken = default);
+        Task<Result<int>> AddDefault(int accountId, string name, CancellationToken cancellationToken = default);
         Task<List<FacilityResponse>> Get(int accountId, CancellationToken cancellationToken = default);
         Task<Result> TransferMember(MemberContext memberContext, int memberId, int facilityId, int accountId,
             CancellationToken cancellationToken = default);

--- a/TipCatDotNet.Api/Services/Payments/IPaymentService.cs
+++ b/TipCatDotNet.Api/Services/Payments/IPaymentService.cs
@@ -4,22 +4,14 @@ using CSharpFunctionalExtensions;
 using TipCatDotNet.Api.Models.Payments;
 using Microsoft.Extensions.Primitives;
 
-namespace TipCatDotNet.Api.Services.Payments
+namespace TipCatDotNet.Api.Services.Payments;
+
+public interface IPaymentService
 {
-    public interface IPaymentService
-    {
-        Task<Result<PaymentDetailsResponse>> GetPreparationDetails(string memberCode, CancellationToken cancellationToken = default);
-
-        Task<Result<PaymentDetailsResponse>> Get(string paymentIntentId, CancellationToken cancellationToken = default);
-
-        Task<Result<PaymentDetailsResponse>> Pay(PaymentRequest request, CancellationToken cancellationToken = default);
-
-        Task<Result<PaymentDetailsResponse>> Capture(string paymentIntentId, CancellationToken cancellationToken = default);
-
-        Task<Result<PaymentDetailsResponse>> Update(string paymentIntentId, PaymentRequest request, CancellationToken cancellationToken = default);
-
-        Task<Result> Cancel(string paymentIntentId, CancellationToken cancellationToken = default);
-        
-        Task<Result> ProcessChanges(string? json, StringValues headers);
-    }
+    Task<Result> Cancel(string paymentIntentId, CancellationToken cancellationToken = default);
+    Task<Result<PaymentDetailsResponse>> Capture(string paymentIntentId, CancellationToken cancellationToken = default);
+    Task<Result<PaymentDetailsResponse>> Get(string memberCode, CancellationToken cancellationToken = default);
+    Task<Result<PaymentDetailsResponse>> Pay(PaymentRequest request, CancellationToken cancellationToken = default);
+    Task<Result> ProcessChanges(string? json, StringValues headers);
+    Task<Result<PaymentDetailsResponse>> Update(string paymentIntentId, PaymentRequest request, CancellationToken cancellationToken = default);
 }

--- a/TipCatDotNet.Api/Services/Payments/IProFormaInvoiceService.cs
+++ b/TipCatDotNet.Api/Services/Payments/IProFormaInvoiceService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TipCatDotNet.Api.Models.Payments;
+
+namespace TipCatDotNet.Api.Services.Payments;
+
+public interface IProFormaInvoiceService
+{
+    Task<ProFormaInvoice> Get(CancellationToken cancellationToken);
+}

--- a/TipCatDotNet.Api/Services/Payments/ProFormaInvoiceService.cs
+++ b/TipCatDotNet.Api/Services/Payments/ProFormaInvoiceService.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using HappyTravel.Money.Enums;
+using HappyTravel.Money.Models;
+using TipCatDotNet.Api.Models.Payments;
+
+namespace TipCatDotNet.Api.Services.Payments;
+
+public class ProFormaInvoiceService : IProFormaInvoiceService
+{
+    public async Task<ProFormaInvoice> Get(CancellationToken cancellationToken)
+    {
+        var serviceFee = new MoneyAmount(2.9m, Currencies.AED);
+
+        return await Task.FromResult(new ProFormaInvoice(amount: null, serviceFee));
+    }
+}

--- a/TipCatDotNet.Api/TipCatDotNet.Api.xml
+++ b/TipCatDotNet.Api/TipCatDotNet.Api.xml
@@ -153,16 +153,9 @@
         </member>
         <member name="M:TipCatDotNet.Api.Controllers.PaymentController.Prepare(System.String)">
             <summary>
-            Prepare payment and get details by member code.
+            Gets payment details by member code.
             </summary>
             <param name="memberCode">Member Code</param>
-            <returns></returns>
-        </member>
-        <member name="M:TipCatDotNet.Api.Controllers.PaymentController.Get(System.String)">
-            <summary>
-            Get payment details by id.
-            </summary>
-            <param name="paymentId">Payment id</param>
             <returns></returns>
         </member>
         <member name="M:TipCatDotNet.Api.Controllers.PaymentController.Pay(TipCatDotNet.Api.Models.Payments.PaymentRequest)">

--- a/TipCatDotNet.ApiTests/PaymentServiceTests.cs
+++ b/TipCatDotNet.ApiTests/PaymentServiceTests.cs
@@ -75,9 +75,9 @@ namespace TipCatDotNet.ApiTests
         public async Task GetDetails_should_return_success()
         {
             var memberCode = "6СD63FG42ASD";
-            var service = new PaymentService(_transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService, _aetherDbContext);
+            var service = new PaymentService(_aetherDbContext, _transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService);
 
-            var (_, isFailure, paymentDetails) = await service.GetPreparationDetails(memberCode);
+            var (_, isFailure, paymentDetails) = await service.Get(memberCode);
 
             Assert.False(isFailure);
             Assert.Equal(1, paymentDetails.Member.Id);
@@ -90,48 +90,9 @@ namespace TipCatDotNet.ApiTests
         public async Task GetDetails_should_return_error_when_member_was_not_found()
         {
             var memberCode = "5СD63FG42ASD";
-            var service = new PaymentService(_transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService, _aetherDbContext);
+            var service = new PaymentService(_aetherDbContext, _transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService);
 
-            var (_, isFailure) = await service.GetPreparationDetails(memberCode);
-
-            Assert.True(isFailure);
-        }
-
-
-        [Fact]
-        public async Task Get_should_return_success()
-        {
-            var paymentIntentId = "pi_3JqtSnKOuc4NSEDL0cP5wDvQ";
-            var service = new PaymentService(_transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService, _aetherDbContext);
-
-            var (_, isFailure, paymentDetails) = await service.Get(paymentIntentId);
-
-            Assert.False(isFailure);
-            Assert.Equal(1, paymentDetails.Member.Id);
-            Assert.Equal("Elizabeth", paymentDetails.Member.FirstName);
-            Assert.Equal("Omara", paymentDetails.Member.LastName);
-        }
-
-
-        [Fact]
-        public async Task Get_should_return_error_when_member_was_not_found()
-        {
-            var paymentIntentId = "pi_3JqtSnKOuc4NSEDL0cP5wDvQ";
-            var paymentIntentServiceMock = new Mock<PaymentIntentService>();
-            paymentIntentServiceMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<PaymentIntentGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new PaymentIntent()
-                {
-                    Object = "payment_intent",
-                    Metadata = new Dictionary<string, string>
-                    {
-                        { "MemberId", "100" },
-                    },
-                });
-
-            var paymentIntentService = paymentIntentServiceMock.Object;
-            var service = new PaymentService(_transactionService, It.IsAny<IOptions<StripeOptions>>(), paymentIntentService, _aetherDbContext);
-
-            var (_, isFailure) = await service.Get(paymentIntentId);
+            var (_, isFailure) = await service.Get(memberCode);
 
             Assert.True(isFailure);
         }
@@ -141,7 +102,7 @@ namespace TipCatDotNet.ApiTests
         public async Task Pay_should_return_error_when_member_does_not_exist()
         {
             var request = new PaymentRequest(101, new MoneyAmount(10, Currencies.USD));
-            var service = new PaymentService(_transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService, _aetherDbContext);
+            var service = new PaymentService(_aetherDbContext, _transactionService, It.IsAny<IOptions<StripeOptions>>(), _paymentIntentService);
 
             var (_, isFailure) = await service.Pay(request);
 

--- a/TipcatDotNet.sln.DotSettings
+++ b/TipcatDotNet.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cherly/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Forma/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jwks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kirill/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Krin/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Back-end logic for #96 

1. `/api/payments/:memberCode` removed
2. `/api/payments/:memberCode/prepare` renamed to `/api/payments/:memberCode`
3. An account operating name, a facility name, and basic pro-forma invoice details were added. For now `proFormaInvoice.amount` is always `null` that means a customer may pay any amount of tips. `proFormaInvoice.serviceFee` is always AED 2.9 for now.

The full method response is:
```json
{
  "member": {
    "id": 1,
    "accountName": "Afterlife",
    "avatarUrl": "https://s3.eu-central-1.amazonaws.com/tipcat-net-avatars/accounts/4/members/1",
    "facilityName": "Afterlife Mercs",
    "firstName": "Rogue",
    "lastName": "Amendiares",
    "position": null
  },
  "clientSecret": null,
  "paymentIntentId": null,
  "proFormaInvoice": {
    "amount": null,
    "serviceFee": {
      "amount": 2.9,
      "currency": "AED"
    }
  }
}
```