### PR TITLE
Feature/parent image for facilities

### DIFF
--- a/TipCatDotNet.Api/Controllers/FacilityAvatarManagementController.cs
+++ b/TipCatDotNet.Api/Controllers/FacilityAvatarManagementController.cs
@@ -28,20 +28,25 @@ public class FacilityAvatarManagementController : BaseController
     /// <param name="accountId">Target account ID</param>
     /// <param name="facilityId">Target facility ID</param>
     /// <param name="file">Avatar as a form file</param>
+    /// <param name="useParent">Set this flag to true instead of file to use account's avatar</param>
     /// <returns></returns>
     [HttpPost]
     [HttpPut]
     [RequestSizeLimit(5 * 1024 * 1024)]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> AddOrUpdate([FromRoute] int accountId, [FromRoute] int facilityId, [FromForm] IFormFile? file)
+    public async Task<IActionResult> AddOrUpdate([FromRoute] int accountId, [FromRoute] int facilityId, [FromForm] IFormFile? file, [FromQuery] bool useParent)
     {
         var (_, isFailure, memberContext, error) = await _memberContextService.Get();
         if (isFailure)
             return BadRequest(error);
 
         var request = new FacilityAvatarRequest(accountId, facilityId, (FormFile?) file);
-        return OkOrBadRequest(await _facilityAvatarManagementService.AddOrUpdate(memberContext, request));
+        var result = useParent
+            ? await _facilityAvatarManagementService.UseParent(memberContext, request)
+            : await _facilityAvatarManagementService.AddOrUpdate(memberContext, request);
+
+        return OkOrBadRequest(result);
     }
 
 

--- a/TipCatDotNet.Api/Models/Images/Validators/FacilityAvatarRequestValidator.cs
+++ b/TipCatDotNet.Api/Models/Images/Validators/FacilityAvatarRequestValidator.cs
@@ -32,6 +32,10 @@ public class FacilityAvatarRequestValidator : AbstractValidator<FacilityAvatarRe
         => Validate(request, cancellationToken);
 
 
+    public ValidationResult ValidateUseParent(FacilityAvatarRequest request, CancellationToken cancellationToken) 
+        => Validate(request, cancellationToken);
+
+
     private ValidationResult Validate(FacilityAvatarRequest request, CancellationToken cancellationToken)
     {
         RuleFor(x => x.AccountId)

--- a/TipCatDotNet.Api/Services/Images/AccountAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/AccountAvatarManagementService.cs
@@ -85,6 +85,10 @@ public class AccountAvatarManagementService : IAvatarManagementService<AccountAv
     }
 
 
+    public Task<Result<string>> UseParent(MemberContext memberContext, AccountAvatarRequest request, CancellationToken cancellationToken = default)
+        => throw new System.NotImplementedException();
+
+
     private readonly IAwsAvatarManagementService _awsImageManagementService;
     private readonly AetherDbContext _context;
     private readonly AvatarManagementServiceOptions _options;

--- a/TipCatDotNet.Api/Services/Images/IAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/IAvatarManagementService.cs
@@ -9,4 +9,5 @@ public interface IAvatarManagementService<in T>
 {
     Task<Result<string>> AddOrUpdate(MemberContext memberContext, T request, CancellationToken cancellationToken = default);
     Task<Result> Remove(MemberContext memberContext, T request, CancellationToken cancellationToken = default);
+    Task<Result<string>> UseParent(MemberContext memberContext, T request, CancellationToken cancellationToken = default);
 }

--- a/TipCatDotNet.Api/Services/Images/MemberAvatarManagementService.cs
+++ b/TipCatDotNet.Api/Services/Images/MemberAvatarManagementService.cs
@@ -85,6 +85,10 @@ public class MemberAvatarManagementService : IAvatarManagementService<MemberAvat
     }
 
 
+    public Task<Result<string>> UseParent(MemberContext memberContext, MemberAvatarRequest request, CancellationToken cancellationToken = default)
+        => throw new System.NotImplementedException();
+
+
     private readonly IAwsAvatarManagementService _awsImageManagementService;
     private readonly AetherDbContext _context;
     private readonly AvatarManagementServiceOptions _options;

--- a/TipCatDotNet.Api/TipCatDotNet.Api.xml
+++ b/TipCatDotNet.Api/TipCatDotNet.Api.xml
@@ -54,13 +54,14 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:TipCatDotNet.Api.Controllers.FacilityAvatarManagementController.AddOrUpdate(System.Int32,System.Int32,Microsoft.AspNetCore.Http.IFormFile)">
+        <member name="M:TipCatDotNet.Api.Controllers.FacilityAvatarManagementController.AddOrUpdate(System.Int32,System.Int32,Microsoft.AspNetCore.Http.IFormFile,System.Boolean)">
             <summary>
             Adds new or update existing facility's avatar. A new one overwrites an old one.
             </summary>
             <param name="accountId">Target account ID</param>
             <param name="facilityId">Target facility ID</param>
             <param name="file">Avatar as a form file</param>
+            <param name="useParent">Set this flag to true instead of file to use account's avatar</param>
             <returns></returns>
         </member>
         <member name="M:TipCatDotNet.Api.Controllers.FacilityAvatarManagementController.Remove(System.Int32,System.Int32)">

--- a/TipCatDotNet.ApiTests/FacilityAvatarManagementServiceTests.cs
+++ b/TipCatDotNet.ApiTests/FacilityAvatarManagementServiceTests.cs
@@ -30,6 +30,7 @@ public class FacilityAvatarManagementServiceTests
 
 
         var aetherDbContextMock = MockContextFactory.Create();
+        aetherDbContextMock.Setup(c => c.Accounts).Returns(DbSetMockProvider.GetDbSetMock(_accounts));
         aetherDbContextMock.Setup(c => c.Facilities).Returns(DbSetMockProvider.GetDbSetMock(_facilities));
 
         _aetherDbContext = aetherDbContextMock.Object;
@@ -61,7 +62,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task AddOrUpdate_should_return_error_when_file_is_not_image()
     {
-        var request = new FacilityAvatarRequest(0, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.doc"));
+        var request = new FacilityAvatarRequest(0, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.doc"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.AddOrUpdate(_memberContext, request);
@@ -73,7 +74,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task AddOrUpdate_should_return_error_when_account_id_is_zero()
     {
-        var request = new FacilityAvatarRequest(0, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(0, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.AddOrUpdate(_memberContext, request);
@@ -85,7 +86,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task AddOrUpdate_should_return_error_when_current_member_does_not_belong_to_account()
     {
-        var request = new FacilityAvatarRequest(2, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(2, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.AddOrUpdate(_memberContext, request);
@@ -97,7 +98,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task AddOrUpdate_should_return_error_when_current_facility_id_is_zero()
     {
-        var request = new FacilityAvatarRequest(1, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(1, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.AddOrUpdate(_memberContext, request);
@@ -109,7 +110,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task AddOrUpdate_should_return_error_when_current_facility_does_not_belong_to_account()
     {
-        var request = new FacilityAvatarRequest(1, 2,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(1, 2, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.AddOrUpdate(_memberContext, request);
@@ -121,7 +122,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task AddOrUpdate_should_return_avatar_url()
     {
-        var request = new FacilityAvatarRequest(1, 1,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(1, 1, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure, url) = await service.AddOrUpdate(_memberContext, request);
@@ -135,7 +136,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task Remove_should_return_error_when_account_id_is_zero()
     {
-        var request = new FacilityAvatarRequest(0, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(0, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.Remove(_memberContext, request);
@@ -147,7 +148,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task Remove_should_return_error_when_current_member_does_not_belong_to_account()
     {
-        var request = new FacilityAvatarRequest(2, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(2, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.Remove(_memberContext, request);
@@ -159,7 +160,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task Remove_should_return_error_when_current_facility_id_is_zero()
     {
-        var request = new FacilityAvatarRequest(1, 0,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(1, 0, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.Remove(_memberContext, request);
@@ -171,7 +172,7 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task Remove_should_return_error_when_current_facility_does_not_belong_to_account()
     {
-        var request = new FacilityAvatarRequest(1, 2,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(1, 2, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.Remove(_memberContext, request);
@@ -183,13 +184,94 @@ public class FacilityAvatarManagementServiceTests
     [Fact]
     public async Task Remove_should_return_result()
     {
-        var request = new FacilityAvatarRequest(1, 1,new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
+        var request = new FacilityAvatarRequest(1, 1, new FormFile(new MemoryStream(Array.Empty<byte>()), 0, 0, string.Empty, "file.jpg"));
         var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
 
         var (_, isFailure) = await service.Remove(_memberContext, request);
 
         Assert.False(isFailure);
     }
+
+
+    [Fact]
+    public async Task UseParent_should_return_error_when_current_member_does_not_belong_to_target_account()
+    {
+        var memberContext = new MemberContext(1, string.Empty, 2, null);
+        var request = new FacilityAvatarRequest(1, 1);
+        var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
+        
+        var (_, isFailure) = await service.UseParent(memberContext, request);
+
+        Assert.True(isFailure);
+    }
+
+
+    [Fact]
+    public async Task UseParent_should_return_error_when_target_facility_is_now_specified()
+    {
+        var request = new FacilityAvatarRequest(1, 0);
+        var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
+        
+        var (_, isFailure) = await service.UseParent(_memberContext, request);
+
+        Assert.True(isFailure);
+    }
+
+
+    [Fact]
+    public async Task UseParent_should_return_error_when_target_facility_does_not_belong_to_target_account()
+    {
+        var request = new FacilityAvatarRequest(1, 2);
+        var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
+        
+        var (_, isFailure) = await service.UseParent(_memberContext, request);
+
+        Assert.True(isFailure);
+    }
+
+
+    [Fact]
+    public async Task UseParent_should_return_error_when_parent_account_has_no_avatar()
+    {
+        var request = new FacilityAvatarRequest(1, 1);
+        var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
+        
+        var (_, isFailure) = await service.UseParent(_memberContext, request);
+
+        Assert.True(isFailure);
+    }
+
+
+    [Fact]
+    public async Task UseParent_should_return_result_when_parent_account_has_avatar()
+    {
+        var memberContext = new MemberContext(1, string.Empty, 2, null);
+        var request = new FacilityAvatarRequest(2, 3);
+        var service = new FacilityAvatarManagementService(_options, _aetherDbContext, _awsImageManagementServiceMock);
+        
+        var (_, isFailure, avatarUrl) = await service.UseParent(memberContext, request);
+
+        Assert.False(isFailure);
+        Assert.Equal(AvatarUrl, avatarUrl);
+    }
+
+
+    private readonly IEnumerable<Account> _accounts = new[]
+    {
+        new Account
+        {
+            Id = 1
+        },
+        new Account
+        {
+            Id = 4
+        },
+        new Account
+        {
+            Id = 2,
+            AvatarUrl = AvatarUrl
+        }
+    };
 
 
     private readonly IEnumerable<Facility> _facilities = new[]
@@ -203,10 +285,17 @@ public class FacilityAvatarManagementServiceTests
         {
             Id = 2,
             AccountId = 4
+        },
+        new Facility
+        {
+            Id = 3,
+            AccountId = 2
         }
     };
 
-
+    
+    private const string AvatarUrl = "https://tipcat.net/avatar.png";
+    
     private readonly AetherDbContext _aetherDbContext;
     private readonly IAwsAvatarManagementService _awsImageManagementServiceMock;
     private readonly MemberContext _memberContext;


### PR DESCRIPTION
According to design layouts, now one could use `useParent` query parameter to set an existed account avatar to a facility like
`POST api/accounts/4/facilities/2/avatar?useParent=true`